### PR TITLE
Small README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ django-scheduler-sample
 
 This is a sample project using django-scheduler and django-scheduler-views
 
-Instalation
+Installation
 =======================
 ```bash
 pip install -r requirements.txt
@@ -12,6 +12,8 @@ pip install -r requirements.txt
 Usage
 =======================
 ```bash
-python manage.py syncdb
+export DJANGO_SETTINGS_MODULE=sample_project.settings
+python manage.py bower install
+python manage.py migrate
 python manage.py runserver
 ```


### PR DESCRIPTION
I ran into two minor issues when trying out this sample project. This commit
- fixes a typo
- adds the needed `bower install` and Django settings steps
- switches from the deprecated `syncdb` command to the new `migrate` command
