### PR TITLE
fixes bower install for django 1.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==1.10
 django-debug-toolbar==1.5
-django-bower==5.0.4
+django-bower==5.2.0
 django-scheduler==0.8


### PR DESCRIPTION
In the wiki, running 'python manage.py bower install' breaks with Django 1.10. It seems the issue was resolved in the release of django-bower 5.2.0 [(see here)](https://github.com/nvbn/django-bower/pull/71) so I'm simply updating the requirements.txt to reflect that. With this version installed + a prompt for selecting the correct jquery version, bower is able to install properly.