### PR TITLE
update required django-scheduler version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==1.10
 django-debug-toolbar==1.5
 django-bower==5.2.0
-django-scheduler==0.8
+django-scheduler==0.8.3


### PR DESCRIPTION
To avoid issue #21, django-scheduler version should be 0.8.3