### PR TITLE
Remove use of namespace in reversed urls

### DIFF
--- a/project_sample/templates/homepage.html
+++ b/project_sample/templates/homepage.html
@@ -43,7 +43,7 @@
       <p>The sample project come with two management commands that enable you to load some data:</p>
       <p><code>./manage.py load_sample_data</code></p>
       <p><code>./manage.py load_example_data</code></p>
-      <p><a href="{% url "scheduler:calendar_list" %}">{% trans "The list of available Calendars." %}</a></p>
+      <p><a href="{% url "calendar_list" %}">{% trans "The list of available Calendars." %}</a></p>
       <p><a href="{% url "fullcalendar" %}">{% trans "Full Calendar Example" %}</a></p>
     </div>
     <div class="col-md-4">

--- a/project_sample/urls.py
+++ b/project_sample/urls.py
@@ -7,14 +7,9 @@ from django.conf import settings
 
 admin.autodiscover()
 
-scheduler_patterns = ([
-    url(r'^schedule/', include('schedule.urls')),
-], 'schedule')
-
-
 urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name="homepage.html"),),
-    url(r'^schedule/', include(scheduler_patterns, namespace='scheduler')),
+    url(r'^schedule/', include('schedule.urls')),
     url(r'^fullcalendar/', TemplateView.as_view(template_name="fullcalendar.html"), name='fullcalendar'),
     url(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
The namespace should be defined in django-scheduler, not in each use. Defining it in django-scheduler allows it to be used internally and consistently.

Fixes #31
Fixes llazzaro/django-scheduler#364