### PR TITLE
Use {% load static %} instead of {% load staticfiles %} in templates

### DIFF
--- a/project_sample/templates/base.html
+++ b/project_sample/templates/base.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles i18n %}
+{% load i18n %}
 {% block extra_head %}
 {{ block.super }}
 {% endblock %}

--- a/project_sample/templates/fullcalendar.html
+++ b/project_sample/templates/fullcalendar.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 
-{% load i18n staticfiles %}
+{% load i18n static %}
 
 {% block head_title %}{% trans "Fullcalendar" %}{% endblock %}
 


### PR DESCRIPTION
Starting with Django 1.10, it is preferable to load the static template
tag library instead of staticfiles. If django.contrib.staticfiles is in
INSTALLED_APPS, the static template tag library will use the staticfiles
app to determine static paths. For additional details, see:

https://docs.djangoproject.com/en/dev/releases/1.10/#django-contrib-staticfiles

> The static template tag now uses django.contrib.staticfiles if it’s in
> INSTALLED_APPS. This is especially useful for third-party apps which
> can now always use {% load static %} (instead of {% load staticfiles
> %} or {% load static from staticfiles %}) and not worry about whether
> or not the staticfiles app is installed.

The staticfiles template tag library will be deprecated and removed in a
future Django version.